### PR TITLE
peerless option for connection

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -168,8 +168,8 @@ func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 func (conn *Connection) updateClusterInfo() (err error) {
 	trace("%s: updateClusterInfo() called", conn.ID)
 
-	if !conn.peerless {
-		trace("clusterMode is false, skipping cluster peer update")
+	if conn.peerless {
+		trace("%s: peerless mode is enabled, cluster info ignored", conn.ID)
 		return nil
 	}
 

--- a/cluster.go
+++ b/cluster.go
@@ -168,6 +168,11 @@ func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 func (conn *Connection) updateClusterInfo() (err error) {
 	trace("%s: updateClusterInfo() called", conn.ID)
 
+	if !conn.peerless {
+		trace("clusterMode is false, skipping cluster peer update")
+		return nil
+	}
+
 	// start with a fresh new cluster
 	var rc rqliteCluster
 	rc.conn = conn

--- a/conn_test.go
+++ b/conn_test.go
@@ -33,8 +33,9 @@ func TestConnectionStringParse(t *testing.T) {
 	requireString(t, "strong", consistencyLevelNames[conn.consistencyLevel])
 	requireString(t, "4000", conn.cluster.leader.port)
 	requireInt(t, 1, conn.timeout)
+	requireBool(t, false, conn.peerless)
 
-	if conn, err = parseUrl("http://user1:pass1@host1.foobar.com:4000/db?level=weak"); err !=nil {
+	if conn, err = parseUrl("http://user1:pass1@host1.foobar.com:4000/db?level=weak&peerless=true"); err !=nil {
 		t.Error(err)
 	}
 
@@ -46,6 +47,8 @@ func TestConnectionStringParse(t *testing.T) {
 	requireString(t, "weak", consistencyLevelNames[conn.consistencyLevel])
 	requireString(t, "4000", conn.cluster.leader.port)
 	requireInt(t, defaultTimeout, conn.timeout)
+	requireBool(t, true, conn.peerless)
+
 }
 
 func requireString(t *testing.T, expected string, actual string) {


### PR DESCRIPTION
This PR adds an option to Connection that allows it to pin itself to the peer in the connection string. This allows devs to use ssh tunnel to rqlite and not have the connection switch to unreachable peers. It should only be used in development.

For example, in evlauthd config, set:

```
ext_db_uri = "http://localhost:8201?peerless=true"
```

And setup SSH tunnel to some node in rqlite cluster

```
ssh -N -L8201:10.1.101.4:8201 sv3-001.dv3.elv
```
