### PR TITLE
host biased peer picking

### DIFF
--- a/api.go
+++ b/api.go
@@ -41,7 +41,7 @@ func (conn *Connection) rqliteApiGet(apiOp apiOperation) ([]byte, error) {
 	}
 
 	// just to be safe, check this
-	peersToTry := conn.cluster.makePeerList()
+	peersToTry := conn.cluster.makePeerList(false)
 	if len(peersToTry) < 1 {
 		return responseBody, errors.New("I don't have any cluster info")
 	}
@@ -117,11 +117,14 @@ PeerLoop:
 func (conn *Connection) rqliteApiPost(apiOp apiOperation, sqlStatements []string) ([]byte, error) {
 	var responseBody []byte
 
+	var favorSeed bool
 	switch apiOp {
 	case api_QUERY:
 		trace("%s: rqliteApiGet() post called for a QUERY of %d statements", conn.ID, len(sqlStatements))
+		favorSeed = true
 	case api_WRITE:
 		trace("%s: rqliteApiGet() post called for a QUERY of %d statements", conn.ID, len(sqlStatements))
+		favorSeed = false
 	default:
 		return responseBody, errors.New("weird! called for an invalid apiOperation in rqliteApiPost()")
 	}
@@ -135,7 +138,7 @@ func (conn *Connection) rqliteApiPost(apiOp apiOperation, sqlStatements []string
 	}
 
 	// just to be safe, check this
-	peersToTry := conn.cluster.makePeerList()
+	peersToTry := conn.cluster.makePeerList(favorSeed)
 	if len(peersToTry) < 1 {
 		return responseBody, errors.New("I don't have any cluster info")
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -80,14 +80,12 @@ func (rc *rqliteCluster) makePeerList(favorSeed bool) []peer {
 	}
 	if favorSeed {
 		trace("favoring seed peer '%s:%s'", rc.seed.hostname, rc.seed.port)
-		if idx := indexOf(rc.seed, peerList); idx > 0 {
+		idx := indexOf(rc.seed, peerList)
+		if idx > 0 && rc.seed.hostname != "" && rc.seed.port != "" {
 			peerList = append(peerList[:idx], peerList[idx+1:]...)
-		}
-		if rc.seed.hostname != "" && rc.seed.port != "" {
 			peerList = append([]peer{rc.seed}, peerList...)
 		}
 	}
-
 	trace("%s: makePeerList() returning this list:", rc.conn.ID)
 	for n, v := range peerList {
 		trace("%s: makePeerList() peer %d -> %s", rc.conn.ID, n, v.hostname+":"+v.port)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -79,7 +79,7 @@ func TestInitCluster(t *testing.T) {
 	}
 }
 
-func TestFavorSeed(t *testing.T) {
+func TestFavoredSeed(t *testing.T) {
 
 	conn := Connection{ID: "testID"}
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -78,3 +78,55 @@ func TestInitCluster(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestFavorSeed(t *testing.T) {
+
+	conn := Connection{ID: "testID"}
+
+	seed := peer{hostname: "127.0.0.1", port: "4001"}
+	leader := peer{hostname: "10.100.1.1", port: "4001"}
+
+	cluster := rqliteCluster{
+		conn:   &conn,
+		leader: leader,
+		seed:   seed,
+		otherPeers: []peer{
+			{hostname: "10.100.2.1", port: "4001"},
+			{hostname: "10.100.3.1", port: "4001"},
+			seed,
+			{hostname: "10.100.4.1", port: "4001"},
+		},
+	}
+
+	peerList := cluster.makePeerList(true)
+	requireBool(t, true, len(peerList) == 5)
+	requireBool(t, true, peerList[0] == seed)
+	requireBool(t, true, peerList[1] == leader)
+
+	peerList = cluster.makePeerList(false)
+	requireBool(t, true, len(peerList) == 5)
+	requireBool(t, true, peerList[0] == leader)
+	requireBool(t, true, peerList[3] == seed)
+
+	cluster = rqliteCluster{
+		conn:   &conn,
+		leader: leader,
+		seed:   seed,
+		otherPeers: []peer{
+			{hostname: "10.100.2.1", port: "4001"},
+			{hostname: "10.100.3.1", port: "4001"},
+			seed,
+			{hostname: "10.100.5.1", port: "4001"},
+		},
+	}
+
+	peerList = cluster.makePeerList(true)
+	requireBool(t, true, len(peerList) == 5)
+	requireBool(t, true, peerList[0] == seed)
+	requireBool(t, true, peerList[1] == leader)
+
+	peerList = cluster.makePeerList(false)
+	requireBool(t, true, len(peerList) == 5)
+	requireBool(t, true, peerList[0] == leader)
+	requireBool(t, true, peerList[3] == seed)
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -126,7 +126,31 @@ func TestFavorSeed(t *testing.T) {
 	requireBool(t, true, peerList[1] == leader)
 
 	peerList = cluster.makePeerList(false)
+
 	requireBool(t, true, len(peerList) == 5)
 	requireBool(t, true, peerList[0] == leader)
 	requireBool(t, true, peerList[3] == seed)
+
+	other := leader
+	cluster = rqliteCluster{
+		conn:   &conn,
+		leader: seed,
+		seed:   seed,
+		otherPeers: []peer{
+			{hostname: "10.100.2.1", port: "4001"},
+			{hostname: "10.100.3.1", port: "4001"},
+			other,
+			{hostname: "10.100.5.1", port: "4001"},
+		},
+	}
+
+	peerList = cluster.makePeerList(true)
+	requireBool(t, true, len(peerList) == 5)
+	requireBool(t, true, peerList[0] == seed)
+	requireBool(t, true, peerList[3] == other)
+
+	peerList = cluster.makePeerList(false)
+	requireBool(t, true, len(peerList) == 5)
+	requireBool(t, true, peerList[0] == seed)
+	requireBool(t, true, peerList[3] == other)
 }

--- a/conn.go
+++ b/conn.go
@@ -288,6 +288,9 @@ func (conn *Connection) initConnection(url string) error {
 		}
 	}
 
+	// Set seed to be the first connection, which is considered the leader at this stage
+	conn.cluster.seed = conn.cluster.leader
+
 	// defaults
 	conn.consistencyLevel = cl_WEAK
 	conn.timeout = defaultTimeout


### PR DESCRIPTION
This PR adds the notion of a seed peer, which is taken as the bootstrap node from configuration. For read queries, the driver will prefer to start with the seed peer, regardless of which peer is the leader. For all other operations, writes and metadata lookups, it will favor the leader. 