### PR TITLE
add support for sqlite RETURNING clause

### DIFF
--- a/api.go
+++ b/api.go
@@ -19,9 +19,92 @@ import (
 	"strings"
 )
 
-type ParameterizedStatement struct {
-	Query     string
-	Arguments []interface{}
+type ParameterizedStatement = Statement
+
+// Statement enables use of parameterized sql statement.
+// example:
+//
+//	x := NewStatement(
+//	   "INSERT INTO Foo (id, name) VALUES ( ?, ? )",
+//	   1,
+//	   "bob")
+//
+// Note: Statement was implemented before gorqlite 'official' has ParameterizedStatement
+type Statement struct {
+	Query     string        // the SQL statement
+	Arguments []interface{} // requests parameters
+	Returning bool          // true if a 'RETURNING' clause is used
+}
+
+func MakeStatement(sql string, params ...interface{}) Statement {
+	return Statement{
+		Query:     sql,
+		Arguments: params,
+	}
+}
+
+func NewStatement(sql string, params ...interface{}) *Statement {
+	return &Statement{
+		Query:     sql,
+		Arguments: params,
+	}
+}
+
+func makeParameterizedStatements(stmts []*Statement) []ParameterizedStatement {
+	if len(stmts) == 0 {
+		return nil
+	}
+	var ret []ParameterizedStatement
+	for _, s := range stmts {
+		ret = append(ret, s.P())
+	}
+	return ret
+}
+
+func (s *Statement) P() Statement {
+	return *s
+}
+
+func (s *Statement) WithReturning(b bool) *Statement {
+	s.Returning = b
+	return s
+}
+
+// Append appends the given sql string and parameters to the current and returns
+// the modified statement.
+func (s *Statement) Append(sql string, params ...interface{}) *Statement {
+	s.Query += sql
+	s.Arguments = append(s.Arguments, params...)
+	return s
+}
+
+// String reconstructs the sql request without parsing (as best effort).
+// Use it for debug.
+func (s *Statement) String() string {
+	sql := strings.ReplaceAll(s.Query, "?", "%v")
+	params := make([]interface{}, 0, len(s.Arguments))
+	for _, p := range s.Arguments {
+		s, ok := p.(string)
+		if ok {
+			params = append(params, fmt.Sprintf("'%s'", s))
+		} else {
+			params = append(params, p)
+		}
+	}
+	return fmt.Sprintf(sql, params...)
+}
+
+func (s *Statement) MarshalJSON() ([]byte, error) {
+	length := len(s.Arguments) + 1
+	if s.Returning {
+		length++
+	}
+	all := make([]interface{}, 0, length)
+	if s.Returning {
+		all = append(all, true)
+	}
+	all = append(append(all, s.Query), s.Arguments...)
+	return json.Marshal(all)
 }
 
 // method: rqliteApiCall() - internally handles api calls,
@@ -123,87 +206,16 @@ func (conn *Connection) rqliteApiGet(ctx context.Context, apiOp apiOperation) ([
 	return conn.rqliteApiCall(ctx, apiOp, "GET", nil)
 }
 
-// Statement enables use of parameterized sql statement.
-// The constructor issues a warning if the number of parameters does not match
-// the count of ? in the query.
-// example:
-//
-//	x := NewStatement(
-//	   "INSERT INTO Foo (id, name) VALUES ( ?, ? )",
-//	   1,
-//	   "bob")
-type Statement struct {
-	Sql        string
-	Parameters []interface{}
-	Warning    string
-}
-
-func (s *Statement) P() ParameterizedStatement {
-	return ParameterizedStatement{
-		Query:     s.Sql,
-		Arguments: s.Parameters,
-	}
-}
-
-func makeParameterizedStatements(stmts []*Statement) []ParameterizedStatement {
-	if len(stmts) == 0 {
-		return nil
-	}
-	var ret []ParameterizedStatement
-	for _, s := range stmts {
-		ret = append(ret, s.P())
-	}
-	return ret
-}
-
-func NewStatement(sql string, params ...interface{}) *Statement {
-
-	warn := ""
-	paramsCount := strings.Count(sql, "?")
-	if paramsCount != len(params) {
-		warn = fmt.Sprintf("Unexpected parameters count: %d, expected: %d",
-			len(params),
-			paramsCount)
-	}
-
-	return &Statement{
-		Sql:        sql,
-		Parameters: params,
-		Warning:    warn,
-	}
-}
-
-// Append appends the given sql string and parameters to the current and returns
-// the modified statement.
-func (s *Statement) Append(sql string, params ...interface{}) *Statement {
-	s.Sql += sql
-	s.Parameters = append(s.Parameters, params...)
-	return s
-}
-
-// String reconstructs the sql request without parsing (as best effort).
-// Use it for debug.
-func (s *Statement) String() string {
-	sql := strings.ReplaceAll(s.Sql, "?", "%v")
-	return fmt.Sprintf(sql, s.Parameters...)
-}
-
-func (s *Statement) MarshalJSON() ([]byte, error) {
-	all := make([]interface{}, 0, len(s.Parameters)+1)
-	all = append(append(all, s.Sql), s.Parameters...)
-	return json.Marshal(all)
-}
-
-//	   method: rqliteApiPost() - for api_QUERY and api_WRITE
+//	   method: rqliteApiPost() - for api_QUERY, api_WRITE & api_REQUEST
 //
 //		- lowest level interface - does not do any JSON unmarshalling
 //		- handles retries
 //		- handles timeouts
-func (conn *Connection) rqliteApiPost(ctx context.Context, apiOp apiOperation, sqlStatements []ParameterizedStatement) ([]byte, error) {
+func (conn *Connection) rqliteApiPost(ctx context.Context, apiOp apiOperation, sqlStatements []Statement) ([]byte, error) {
 	var responseBody []byte
 
-	// Allow only api_QUERY and api_WRITE
-	if apiOp != api_QUERY && apiOp != api_WRITE {
+	// allow only api_QUERY, api_WRITE & api_REQUEST
+	if apiOp != api_QUERY && apiOp != api_WRITE && apiOp != api_REQUEST {
 		return responseBody, errors.New("rqliteApiPost() called for invalid api operation")
 	}
 
@@ -213,6 +225,12 @@ func (conn *Connection) rqliteApiPost(ctx context.Context, apiOp apiOperation, s
 
 	for _, statement := range sqlStatements {
 		formattedStatement := make([]interface{}, 0, len(statement.Arguments)+1)
+		if statement.Returning {
+			if apiOp != api_REQUEST {
+				return responseBody, errors.New("returning clause only available on api REQUEST")
+			}
+			formattedStatement = append(formattedStatement, statement.Returning)
+		}
 		formattedStatement = append(formattedStatement, statement.Query)
 		formattedStatement = append(formattedStatement, statement.Arguments...)
 		formattedStatements = append(formattedStatements, formattedStatement)

--- a/closed_test.go
+++ b/closed_test.go
@@ -49,7 +49,7 @@ func TestClosedConnection(t *testing.T) {
 	})
 
 	t.Run("SetConsistencyLevel", func(t *testing.T) {
-		err := conn.SetConsistencyLevel(ConsistencyLevelNone)
+		err := conn.SetConsistency(ConsistencyLevelNone)
 		if err == nil {
 			t.Errorf("expected error, got nil")
 		}

--- a/cluster.go
+++ b/cluster.go
@@ -112,9 +112,11 @@ func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 		builder.WriteString("/db/query")
 	case api_WRITE:
 		builder.WriteString("/db/execute")
+	case api_REQUEST:
+		builder.WriteString("/db/request")
 	}
 
-	if apiOp == api_QUERY || apiOp == api_WRITE {
+	if apiOp == api_QUERY || apiOp == api_WRITE || apiOp == api_REQUEST {
 		builder.WriteString("?timings&level=")
 		builder.WriteString(consistencyLevelNames[conn.consistencyLevel])
 		if conn.wantsTransactions {
@@ -134,6 +136,8 @@ func (conn *Connection) assembleURL(apiOp apiOperation, p peer) string {
 		trace("%s: assembled URL for an api_NODES: %s", conn.ID, builder.String())
 	case api_WRITE:
 		trace("%s: assembled URL for an api_WRITE: %s", conn.ID, builder.String())
+	case api_REQUEST:
+		trace("%s: assembled URL for an api_REQUEST: %s", conn.ID, builder.String())
 	}
 
 	return builder.String()

--- a/conn_test.go
+++ b/conn_test.go
@@ -72,21 +72,21 @@ func TestSetConsistencyLevel(t *testing.T) {
 	}
 
 	t.Run("Less than none", func(t *testing.T) {
-		err := conn.SetConsistencyLevel(-1)
+		err := conn.SetConsistency(-1)
 		if err == nil {
 			t.Errorf("expected error, got nil")
 		}
 	})
 
 	t.Run("Greater than strong", func(t *testing.T) {
-		err := conn.SetConsistencyLevel(100)
+		err := conn.SetConsistency(100)
 		if err == nil {
 			t.Errorf("expected error, got nil")
 		}
 	})
 
 	t.Run("None", func(t *testing.T) {
-		err := conn.SetConsistencyLevel(ConsistencyLevelNone)
+		err := conn.SetConsistency(ConsistencyLevelNone)
 		if err != nil {
 			t.Errorf("expected nil, got %v", err)
 		}

--- a/gorqlite.go
+++ b/gorqlite.go
@@ -52,6 +52,7 @@ const (
 	api_STATUS
 	api_WRITE
 	api_NODES
+	api_REQUEST
 )
 
 func init() {

--- a/gorqlite_test.go
+++ b/gorqlite_test.go
@@ -18,7 +18,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("opening connection: %v", err)
 	}
 
-	err = conn.SetConsistencyLevel(ConsistencyLevelStrong)
+	err = conn.SetConsistency(ConsistencyLevelStrong)
 	if err != nil {
 		log.Fatalf("setting consistency level: %v", err)
 	}

--- a/request.go
+++ b/request.go
@@ -1,0 +1,203 @@
+package gorqlite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// RequestOne wraps Write() into a single-statement method.
+//
+// RequestOne uses context.Background() internally; to specify the context, use RequestOneContext.
+func (conn *Connection) RequestOne(sqlStatement string) (RequestResult, error) {
+	wra, err := conn.Request([]string{sqlStatement})
+	return wra[0], err
+}
+
+// RequestOneContext wraps RequestContext() into a single-statement
+func (conn *Connection) RequestOneContext(ctx context.Context, sqlStatement string) (RequestResult, error) {
+	wra, err := conn.RequestContext(ctx, []string{sqlStatement})
+	return wra[0], err
+}
+
+// RequestOneParameterized wraps WriteParameterized() into a single-statement method.
+//
+// RequestOneParameterized uses context.Background() internally; to specify the context, use RequestOneParameterizedContext.
+func (conn *Connection) RequestOneParameterized(statement ParameterizedStatement) (RequestResult, error) {
+	wra, err := conn.RequestParameterized([]ParameterizedStatement{statement})
+	return wra[0], err
+}
+
+// RequestOneParameterizedContext wraps RequestParameterizedContext into
+// a single-statement method.
+func (conn *Connection) RequestOneParameterizedContext(ctx context.Context, statement ParameterizedStatement) (RequestResult, error) {
+	wra, err := conn.RequestParameterizedContext(ctx, statement)
+	return wra[0], err
+}
+
+func (conn *Connection) RequestStmt(ctx context.Context, sqlStatements ...*Statement) ([]RequestResult, error) {
+	return conn.RequestParameterizedContext(ctx, makeParameterizedStatements(sqlStatements)...)
+}
+
+// Request is used to perform DDL/DML in the database synchronously without parameters.
+//
+// Request uses context.Background() internally; to specify the context, use RequestContext.
+// To use Request with parameterized queries, use RequestParameterized.
+func (conn *Connection) Request(sqlStatements []string) ([]RequestResult, error) {
+	parameterizedStatements := make([]ParameterizedStatement, 0, len(sqlStatements))
+	for _, sqlStatement := range sqlStatements {
+		parameterizedStatements = append(parameterizedStatements, ParameterizedStatement{
+			Query: sqlStatement,
+		})
+	}
+
+	return conn.RequestParameterized(parameterizedStatements)
+}
+
+// RequestContext is used to perform DDL/DML in the database synchronously without parameters.
+//
+// To use RequestContext with parameterized queries, use RequestParameterizedContext.
+func (conn *Connection) RequestContext(ctx context.Context, sqlStatements []string) ([]RequestResult, error) {
+	parameterizedStatements := make([]ParameterizedStatement, 0, len(sqlStatements))
+	for _, sqlStatement := range sqlStatements {
+		parameterizedStatements = append(parameterizedStatements, ParameterizedStatement{
+			Query: sqlStatement,
+		})
+	}
+
+	return conn.RequestParameterizedContext(ctx, parameterizedStatements...)
+}
+
+// RequestParameterized is used to perform DDL/DML in the database synchronously.
+//
+// RequestParameterized takes an array of SQL statements, and returns an equal-sized array of WriteResults,
+// each corresponding to the SQL statement that produced it.
+//
+// All statements are executed as a single transaction.
+//
+// RequestParameterized returns an error if one is encountered during its operation.
+// If it's something like a call to the rqlite API, then it'll return that error.
+// If one statement out of several has an error, it will return a generic
+// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+//
+// RequestParameterized uses context.Background() internally; to specify the context, use RequestParameterizedContext.
+func (conn *Connection) RequestParameterized(sqlStatements []ParameterizedStatement) ([]RequestResult, error) {
+	return conn.RequestParameterizedContext(context.Background(), sqlStatements...)
+}
+
+// RequestParameterizedContext is used to perform DDL/DML in the database synchronously.
+//
+// RequestParameterizedContext takes an array of SQL statements, and returns an equal-sized array of WriteResults,
+// each corresponding to the SQL statement that produced it.
+//
+// All statements are executed as a single transaction.
+//
+// RequestParameterizedContext returns an error if one is encountered during its operation.
+// If it's something like a call to the rqlite API, then it'll return that error.
+// If one statement out of several has an error, it will return a generic
+// "there were %d statement errors" and you'll have to look at the individual statement's Err for more info.
+func (conn *Connection) RequestParameterizedContext(ctx context.Context, sqlStatements ...ParameterizedStatement) ([]RequestResult, error) {
+	results := make([]RequestResult, 0)
+
+	if conn.hasBeenClosed {
+		results = append(results, RequestResult{Err: ErrClosed})
+		return results, ErrClosed
+	}
+
+	trace("%s: Write() for %d statements", conn.ID, len(sqlStatements))
+
+	response, err := conn.rqliteApiPost(ctx, api_REQUEST, sqlStatements)
+	if err != nil {
+		trace("%s: rqliteApiCall() ERROR: %s", conn.ID, err.Error())
+		results = append(results, RequestResult{Err: err})
+		return results, err
+	}
+	trace("%s: rqliteApiCall() OK", conn.ID)
+
+	var sections map[string]interface{}
+	err = json.Unmarshal(response, &sections)
+	if err != nil {
+		trace("%s: json.Unmarshal() ERROR: %s", conn.ID, err.Error())
+		results = append(results, RequestResult{Err: err})
+		return results, err
+	}
+	// stop if we got an error from the api
+	if errMsg, ok := sections["error"].(string); ok && errMsg != "" {
+		trace("%s: api ERROR: %s", conn.ID, errMsg)
+
+		err = fmt.Errorf("%s", errMsg)
+		results = append(results, RequestResult{Err: err})
+		return results, err
+	}
+
+	// at this point, we have a "results" section and
+	// a "time" section.  we can ignore the latter.
+	//type Response struct {
+	//	Results     *DBResults `json:"results,omitempty"` : either
+	//                               ExecuteResult
+	//                               QueryRows
+	//                               ExecuteQueryResponse
+	//	Error       string     `json:"error,omitempty"`
+	//	Time        float64    `json:"time,omitempty"`
+	//}
+
+	resultsArray, ok := sections["results"].([]interface{})
+	if !ok {
+		err = errors.New("result key is missing from response")
+		trace("%s: sections[\"results\"] ERROR: %s", conn.ID, err)
+		results = append(results, RequestResult{Err: err})
+		return results, err
+	}
+
+	trace("%s: I have %d result(s) to parse", conn.ID, len(resultsArray))
+	numStatementErrors := 0
+	for n, k := range resultsArray {
+		trace("%s: starting on result %d", conn.ID, n)
+		thisRR := conn.makeRequestResult(k.(map[string]interface{}))
+		if thisRR.Err != nil {
+			numStatementErrors++
+		} else if !thisRR.Write.IsZero() {
+			trace("%s: this result (LII,RA,T): %d %d %f", conn.ID, thisRR.Write.LastInsertID, thisRR.Write.RowsAffected, thisRR.Write.Timing)
+		} else {
+			trace("%s: this result (#col,time) %d %f", conn.ID, len(thisRR.Query.columns), thisRR.Query.Timing)
+		}
+		results = append(results, thisRR)
+	}
+
+	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
+	if numStatementErrors > 0 {
+		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
+	}
+
+	return results, nil
+}
+
+func (conn *Connection) makeRequestResult(thisResult map[string]interface{}) RequestResult {
+	_, cok := thisResult["columns"].([]interface{})
+	_, tok := thisResult["types"].([]interface{})
+	var q QueryResult
+	var w WriteResult
+	var err error
+	if cok && tok {
+		q = conn.makeQueryResult(thisResult)
+		err = q.Err
+	} else {
+		w = conn.makeWriteResult(thisResult)
+		err = w.Err
+	}
+	return RequestResult{
+		Err:   err,
+		Write: w,
+		Query: q,
+	}
+}
+
+// RequestResult holds the result of a request.
+// Err is assigned if there was an error, otherwise only one of Write or Query
+// is assigned and has its field ID set.
+type RequestResult struct {
+	Err   error // don't trust the rest if this isn't nil
+	Write WriteResult
+	Query QueryResult
+}

--- a/write.go
+++ b/write.go
@@ -49,8 +49,7 @@ import (
 
  * *****************************************************************/
 
-// WriteOne wraps Write() into a single-statement
-// method.
+// WriteOne wraps Write() into a single-statement method.
 //
 // WriteOne uses context.Background() internally; to specify the context, use WriteOneContext.
 func (conn *Connection) WriteOne(sqlStatement string) (wr WriteResult, err error) {
@@ -144,9 +143,7 @@ func (conn *Connection) WriteParameterizedContext(ctx context.Context, sqlStatem
 	results = make([]WriteResult, 0)
 
 	if conn.hasBeenClosed {
-		var errResult WriteResult
-		errResult.Err = ErrClosed
-		results = append(results, errResult)
+		results = append(results, WriteResult{Err: ErrClosed})
 		return results, ErrClosed
 	}
 
@@ -155,9 +152,7 @@ func (conn *Connection) WriteParameterizedContext(ctx context.Context, sqlStatem
 	response, err := conn.rqliteApiPost(ctx, api_WRITE, sqlStatements)
 	if err != nil {
 		trace("%s: rqliteApiCall() ERROR: %s", conn.ID, err.Error())
-		var errResult WriteResult
-		errResult.Err = err
-		results = append(results, errResult)
+		results = append(results, WriteResult{Err: err})
 		return results, err
 	}
 	trace("%s: rqliteApiCall() OK", conn.ID)
@@ -166,68 +161,77 @@ func (conn *Connection) WriteParameterizedContext(ctx context.Context, sqlStatem
 	err = json.Unmarshal(response, &sections)
 	if err != nil {
 		trace("%s: json.Unmarshal() ERROR: %s", conn.ID, err.Error())
-		var errResult WriteResult
-		errResult.Err = err
-		results = append(results, errResult)
+		results = append(results, WriteResult{Err: err})
+		return results, err
+	}
+	// stop if we got an error from the api
+	if errMsg, ok := sections["error"].(string); ok && errMsg != "" {
+		trace("%s: api ERROR: %s", conn.ID, errMsg)
+
+		err = fmt.Errorf("%s", errMsg)
+		results = append(results, WriteResult{Err: err})
 		return results, err
 	}
 
 	// at this point, we have a "results" section and
-	// a "time" section.  we can igore the latter.
+	// a "time" section.  we can ignore the latter.
 
 	resultsArray, ok := sections["results"].([]interface{})
 	if !ok {
 		err = errors.New("result key is missing from response")
 		trace("%s: sections[\"results\"] ERROR: %s", conn.ID, err)
-		var errResult WriteResult
-		errResult.Err = err
-		results = append(results, errResult)
+		results = append(results, WriteResult{Err: err})
 		return results, err
 	}
+
 	trace("%s: I have %d result(s) to parse", conn.ID, len(resultsArray))
 	numStatementErrors := 0
 	for n, k := range resultsArray {
 		trace("%s: starting on result %d", conn.ID, n)
-		thisResult := k.(map[string]interface{})
-
-		var thisWR WriteResult
-		thisWR.conn = conn
-
-		// did we get an error?
-		_, ok := thisResult["error"]
-		if ok {
-			trace("%s: have an error on this result: %s", conn.ID, thisResult["error"].(string))
-			thisWR.Err = errors.New(thisResult["error"].(string))
-			results = append(results, thisWR)
-			numStatementErrors += 1
-			continue
+		thisWR := conn.makeWriteResult(k.(map[string]interface{}))
+		if thisWR.Err != nil {
+			numStatementErrors++
+		} else {
+			trace("%s: this result (LII,RA,T): %d %d %f", conn.ID, thisWR.LastInsertID, thisWR.RowsAffected, thisWR.Timing)
 		}
-
-		_, ok = thisResult["last_insert_id"]
-		if ok {
-			thisWR.LastInsertID = int64(thisResult["last_insert_id"].(float64))
-		}
-
-		_, ok = thisResult["rows_affected"] // could be zero for a CREATE
-		if ok {
-			thisWR.RowsAffected = int64(thisResult["rows_affected"].(float64))
-		}
-		_, ok = thisResult["time"] // could be nil
-		if ok {
-			thisWR.Timing = thisResult["time"].(float64)
-		}
-
-		trace("%s: this result (LII,RA,T): %d %d %f", conn.ID, thisWR.LastInsertID, thisWR.RowsAffected, thisWR.Timing)
 		results = append(results, thisWR)
 	}
 
 	trace("%s: finished parsing, returning %d results", conn.ID, len(results))
-
 	if numStatementErrors > 0 {
 		return results, fmt.Errorf("there were %d statement errors", numStatementErrors)
-	} else {
-		return results, nil
 	}
+
+	return results, nil
+}
+
+func (conn *Connection) makeWriteResult(thisResult map[string]interface{}) WriteResult {
+	thisWR := WriteResult{
+		ID: conn.ID,
+	}
+
+	// did we get an error?
+	_, ok := thisResult["error"]
+	if ok {
+		trace("%s: have an error on this result: %s", conn.ID, thisResult["error"].(string))
+		thisWR.Err = errors.New(thisResult["error"].(string))
+		return thisWR
+	}
+
+	_, ok = thisResult["last_insert_id"]
+	if ok {
+		thisWR.LastInsertID = int64(thisResult["last_insert_id"].(float64))
+	}
+
+	_, ok = thisResult["rows_affected"] // could be zero for a CREATE
+	if ok {
+		thisWR.RowsAffected = int64(thisResult["rows_affected"].(float64))
+	}
+	_, ok = thisResult["time"] // could be nil
+	if ok {
+		thisWR.Timing = thisResult["time"].(float64)
+	}
+	return thisWR
 }
 
 // QueueOne is a convenience method that wraps Queue into a single-statement.
@@ -324,9 +328,13 @@ func (conn *Connection) QueueParameterizedContext(ctx context.Context, sqlStatem
 //
 // Write() returns an array of WriteResult vars, while WriteOne() returns a single WriteResult.
 type WriteResult struct {
-	Err          error // don't trust the rest if this isn't nil
-	Timing       float64
-	RowsAffected int64 // affected by the change
-	LastInsertID int64 // if relevant, otherwise zero value
-	conn         *Connection
+	ID           string  // ID of connection
+	Err          error   // don't trust the rest if this isn't nil
+	Timing       float64 // timing
+	RowsAffected int64   // affected by the change
+	LastInsertID int64   // if relevant, otherwise zero value
+}
+
+func (w *WriteResult) IsZero() bool {
+	return w.Timing == 0 && w.RowsAffected == 0 && w.LastInsertID == 0 && w.Err == nil
 }


### PR DESCRIPTION
Add support for [sqlite RETURNING clause](https://www.sqlite.org/lang_returning.html) available through [rqlite/pull/5](https://github.com/eluv-io/rqlite/pull/5).

